### PR TITLE
feat/more-sats

### DIFF
--- a/SatAR Lite/Cache.swift
+++ b/SatAR Lite/Cache.swift
@@ -8,31 +8,38 @@ import CSV
 /// Amateur radio satellite with ham radio frequencies and modes
 struct ARS {
     let commonName: String
-    let noradIndex: Int?
+    let noradIndex: Int
     let uplink: String
     let downlink: String
     let beacon: String
     let mode: String
     let callsign: String
-    let status: String
     
     init(fromJE9PEL row: [String]) throws {
         guard row.count == 8 else {
             throw ARSError.badJE9PEL
         }
         
+        guard let number = Int(row[1]) else {
+            throw ARSError.badJE9PEL
+        }
+        
+        guard row[7] == "active" else {
+            throw ARSError.inactiveJE9PEL
+        }
+        
         commonName = row[0]
-        noradIndex = Int(row[1])
+        noradIndex = number
         uplink = row[2]
         downlink = row[3]
         beacon = row[4]
         mode = row[5]
         callsign = row[6]
-        status = row[7]
     }
     
     enum ARSError: Error {
         case badJE9PEL
+        case inactiveJE9PEL
     }
 }
 
@@ -40,19 +47,19 @@ struct ARS {
 /// TODO: replace this with data in views
 struct Cache {
     
-    /// Cached satellite orbital data
-    static var tles: [TLE] = []
-    
     /// Cached satellite radio data
-    static var arss: [ARS] = []
+    static var sats: [ARS] = []
+    
+    /// Secret stash of orbital data
+    private static var tles: [Int:TLE] = [:]
     
     /// Secret stash of propagators
     private static var satellites: [Int:Satellite] = [:]
     
     /// Create satellite and propagator if necessary
-    static func getSat(noradId: Int) -> Satellite {
+    private static func getSat(noradId: Int) -> Satellite {
         guard let sat = satellites[noradId] else {
-            let tle = tles.first { tle in tle.noradIndex == noradId }!
+            let tle = tles[noradId]!
             let sat = Satellite(withTLE: tle)
             satellites[noradId] = sat
             return sat
@@ -79,65 +86,67 @@ struct Cache {
     /// Download and cache both satellite and radio data
     static func loadAll() -> Promise<Void> {
         async {
-            try await(when(fulfilled: [
-                loadTLEs(),
-                loadRadioData()
-            ]))
-            
-            // TODO: debugging
-            // Search for TLEs that are missing radio data
-            for tle in tles {
-                let found = arss.contains { ars in
-                    ars.noradIndex == tle.noradIndex
-                }
-                if !found {
-                    print("loadAll: missing radio: \(tle.noradIndex) \(tle.commonName)")
+            tles = try await(loadTLEs())
+            let all = try await(loadRadioData())
+
+            // Search for radios with missing orbital data
+            for sat in all {
+                if tles[sat.noradIndex] == nil {
+                    print("loadAll: missing orbital data: \(sat.commonName) \(sat.noradIndex)")
+                } else {
+                    sats.append(sat)
                 }
             }
         }
     }
     
-    /// Download and cache just radio data
+    /// Download and cache radio data
     /// http://www.ne.jp/asahi/hamradio/je9pel/satslist.htm
     /// http://www.dk3wn.info/p/?page_id=29535
-    static func loadRadioData() -> Promise<Void> {
+    static func loadRadioData() -> Promise<[ARS]> {
         async {
             let url = URL(string: "https://www.ne.jp/asahi/hamradio/je9pel/satslist.csv")!
             let file = getDocumentsDirectory().appendingPathComponent("satslist.csv")
             let delimiter: Unicode.Scalar = ";"
             
             // Download file, ignoring failure
-            try? await(downloadIfStale(url: url, to: file, minutes: 1))
+            try? await(downloadIfStale(url: url, to: file, minutes: 1440))
             
             // Load data into cache from saved file
-            arss.removeAll()
+            var active: [ARS] = []
+            var ignored = 0
             let stream = InputStream(url: file)!
             let csv = try CSVReader(stream: stream, delimiter: delimiter)
             while let row = csv.next() {
                 // Radio details from je9pel might have parse errors
                 if let ars = try? ARS(fromJE9PEL: row) {
-                    arss.append(ars)
+                    active.append(ars)
                 } else {
-                    print("loadRadioData: warning, ignored \(row)")
+                    ignored += 1
                 }
             }
             
-            print("loadRadioData: loaded \(arss.count) ARSs")
+            print("loadRadioData: using \(active.count) sats")
+            print("loadRadioData: ignored \(ignored) sats")
+            
+            return active
         }
     }
     
-    /// Download and cache just satellites
+    /// Download and cache orbital elements
+    /// NOTE: This source is missing 12 satellites denoted active on JE3PEL
+    /// NOTE: I know that 2 are incorrectly marked as active, Space-Track has TLEs for 7 others, leaving 3 as "from caltech"???
     /// https://celestrak.com/NORAD/elements/
-    static func loadTLEs() -> Promise<Void> {
+    static func loadTLEs() -> Promise<[Int:TLE]> {
         return async {
-            let url = URL(string: "https://celestrak.com/NORAD/elements/amateur.txt")!
-            let file = getDocumentsDirectory().appendingPathComponent("amateur.txt")
+            let url = URL(string: "https://celestrak.com/NORAD/elements/active.txt")!
+            let file = getDocumentsDirectory().appendingPathComponent("active.txt")
             
             // Download file, ignoring failure
-            try? await(downloadIfStale(url: url, to: file, minutes: 1))
+            try? await(downloadIfStale(url: url, to: file, minutes: 1440))
             
             // Load data into cache from saved file
-            tles.removeAll()
+            var batch: [Int:TLE] = [:]
             let text: String = try String(contentsOf: file, encoding: .utf8)
             let lines = text.components(separatedBy: .newlines).filter { (s: String) -> Bool in s.count > 0 }
             for b in 0..<lines.count / 3 {
@@ -145,10 +154,11 @@ struct Cache {
                 // TLEs from Celestrak will always parse
                 // Error is not handled here so it will bubble up if any fail to parse
                 let tle = try TLE(lines[i], lines[i+1], lines[i+2])
-                tles.append(tle)
+                batch[tle.noradIndex] = tle
             }
             
-            print("loadTLEs: loaded \(tles.count) TLEs")
+            print("loadTLEs: loaded \(batch.count) tles")
+            return batch
         }
     }
     

--- a/SatAR Lite/Cache.swift
+++ b/SatAR Lite/Cache.swift
@@ -83,34 +83,6 @@ struct Cache {
         return eci2top(julianDays: julian, satCel: eci, obsLLA: obs)
     }
     
-    /// WIP: Calculate next topocentric up positive time
-    /// Currently wrong
-    static func getNextRise(noradId: Int, date: Date, lat: Double, lon: Double) -> Date? {
-        let now = date.julianDate
-        let obs = LatLonAlt(lat: lat, lon: lon, alt: 0)
-        let sat = getSat(noradId: noradId)
-        let onemin = 0.003472222222
-        
-        let eci = sat.position(julianDays: now)
-        let top = eci2top(julianDays: now, satCel: eci, obsLLA: obs)
-        
-        // Is satellite already in sky?
-        if top.z >= 0 {
-            return nil
-        }
-       
-        // Find satellite rise
-        for days in stride(from:0.0, through: 5.0, by: onemin) {
-            let eci = sat.position(julianDays: now + days)
-            let top = eci2top(julianDays: now + days, satCel: eci, obsLLA: obs)
-            if top.z > 0 {
-                return Date(julianDate: now + days)
-            }
-        }
-        
-        return nil
-    }
-    
     /// Download and cache both satellite and radio data
     static func loadAll() -> Promise<Void> {
         async {

--- a/SatAR Lite/SatelliteListTableViewController.swift
+++ b/SatAR Lite/SatelliteListTableViewController.swift
@@ -5,18 +5,18 @@ class SatelliteListViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         // List all satellites, even untracked ones
-        return Cache.tles.count
+        return Cache.sats.count
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = UITableViewCell(style: UITableViewCell.CellStyle.default, reuseIdentifier: "cell")
         
         // Populate the name and visibility checkmark
-        let tle = Cache.tles[indexPath.row]
+        let sat = Cache.sats[indexPath.row]
         
-        cell.textLabel?.text = tle.commonName
+        cell.textLabel?.text = sat.commonName
         
-        if tracking[tle.noradIndex] ?? false {
+        if tracking[sat.noradIndex] ?? false {
             cell.accessoryType = UITableViewCell.AccessoryType.checkmark
         }
         
@@ -27,11 +27,11 @@ class SatelliteListViewController: UITableViewController {
         // UITableViewCell.AccessoryType.<acc> may be useful
         
         // Toggle checkmark and visibility
-        let tle = Cache.tles[indexPath.row]
+        let sat = Cache.sats[indexPath.row]
         
-        tracking[tle.noradIndex] = !(tracking[tle.noradIndex] ?? false)
+        tracking[sat.noradIndex] = !(tracking[sat.noradIndex] ?? false)
         
-        if (tracking[tle.noradIndex]!) {
+        if (tracking[sat.noradIndex]!) {
             tableView.cellForRow(at: indexPath)?.accessoryType = UITableViewCell.AccessoryType.checkmark
         } else {
             tableView.cellForRow(at: indexPath)?.accessoryType = UITableViewCell.AccessoryType.none


### PR DESCRIPTION
Increases satellite list from 70 to 235 using larger active.txt TLE list from CelesTrak, and shuffles the proper list from TLEs to amateur radio satellite records from JE3PEL so that it is easier to look up TLEs and skip the 12 satellites that do not have orbital elements in active.txt.