### PR TITLE
Refactor Cache to focus on TLEs again

### DIFF
--- a/SatAR Lite/AppDelegate.swift
+++ b/SatAR Lite/AppDelegate.swift
@@ -1,8 +1,5 @@
 import UIKit
 
-/// TODO Magic global?
-var tracking: [Int:Bool] = [:]
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 

--- a/SatAR Lite/Cache.swift
+++ b/SatAR Lite/Cache.swift
@@ -5,9 +5,9 @@ import AwaitKit
 import PMKFoundation
 import CSV
 
-/// Amateur radio satellite with ham radio frequencies and modes
-struct ARS {
-    let commonName: String
+/// Amateur radio satellite record from JE3PEL's list
+struct JE3PEL {
+    let name: String
     let noradIndex: Int
     let uplink: String
     let downlink: String
@@ -15,20 +15,20 @@ struct ARS {
     let mode: String
     let callsign: String
     
-    init(fromJE9PEL row: [String]) throws {
+    init(fromCSV row: [String]) throws {
         guard row.count == 8 else {
-            throw ARSError.badJE9PEL
-        }
-        
-        guard let number = Int(row[1]) else {
-            throw ARSError.badJE9PEL
+            throw JE3PELError.bad
         }
         
         guard row[7] == "active" else {
-            throw ARSError.inactiveJE9PEL
+            throw JE3PELError.inactive
         }
         
-        commonName = row[0]
+        guard let number = Int(row[1]) else {
+            throw JE3PELError.untrackable
+        }
+        
+        name = row[0]
         noradIndex = number
         uplink = row[2]
         downlink = row[3]
@@ -37,44 +37,32 @@ struct ARS {
         callsign = row[6]
     }
     
-    enum ARSError: Error {
-        case badJE9PEL
-        case inactiveJE9PEL
+    enum JE3PELError: Error {
+        case bad
+        case inactive
+        case untrackable
     }
 }
 
-/// Temporary global cache struct
-/// TODO: replace this with data in views
-struct Cache {
+/// Everything an amateur radio operator can know about one object in Earth orbit
+class AmateurRadioSatellite: Hashable {
+    let tle: TLE
+    let radios: [JE3PEL]
+    var tracking: Bool = false
     
-    /// Cached satellite radio data
-    static var sats: [ARS] = []
+    private let sat: Satellite
     
-    /// Secret stash of orbital data
-    private static var tles: [Int:TLE] = [:]
-    
-    /// Secret stash of propagators
-    private static var satellites: [Int:Satellite] = [:]
-    
-    /// Create satellite and propagator if necessary
-    private static func getSat(noradId: Int) -> Satellite {
-        guard let sat = satellites[noradId] else {
-            let tle = tles[noradId]!
-            let sat = Satellite(withTLE: tle)
-            satellites[noradId] = sat
-            return sat
-        }
-        
-        return sat
+    init(tle: TLE, radios: [JE3PEL]) {
+        self.tle = tle
+        self.radios = radios
+        self.sat = Satellite(withTLE: tle)
     }
     
     /// Calculate next topocentric coordinates (south, east, up)
-    static func getTopo(noradId: Int, date: Date, lat: Double, lon: Double) -> Vector {
+    func getTopo(date: Date, lat: Double, lon: Double) -> Vector {
+        // Types expected by SatelliteKit
         let julian = date.julianDate
         let obs = LatLonAlt(lat: lat, lon: lon, alt: 0)
-        
-        // Load propagator from memory
-        let sat = getSat(noradId: noradId)
         
         // Run propagator
         let eci = sat.position(julianDays: julian)
@@ -83,27 +71,58 @@ struct Cache {
         return eci2top(julianDays: julian, satCel: eci, obsLLA: obs)
     }
     
+    //MARK: - Hashable
+    
+    static func == (lhs: AmateurRadioSatellite, rhs: AmateurRadioSatellite) -> Bool {
+        return lhs.tle.noradIndex == rhs.tle.noradIndex
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(tle.noradIndex)
+    }
+}
+
+/// Temporary global cache struct
+/// TODO: replace this with data in views
+struct Cache {
+    
+    /// The Cache
+    static var list: [AmateurRadioSatellite] = []
+    
     /// Download and cache both satellite and radio data
     static func loadAll() -> Promise<Void> {
         async {
-            tles = try await(loadTLEs())
-            let all = try await(loadRadioData())
-
-            // Search for radios with missing orbital data
-            for sat in all {
-                if tles[sat.noradIndex] == nil {
-                    print("loadAll: missing orbital data: \(sat.commonName) \(sat.noradIndex)")
-                } else {
-                    sats.append(sat)
+            let tles = try await(loadTLEs())
+            let radios = try await(loadRadioData())
+            
+            // Treat each TLE as unique satellite, find related radios or ignore
+            // TODO: eventually return a fresh list instead of mutating static global
+            list.removeAll()
+            for tle in tles {
+                let related = radios.filter { record in record.noradIndex == tle.noradIndex }
+                if related.count > 0 {
+                    list.append(AmateurRadioSatellite(tle: tle, radios: related))
                 }
             }
+            
+            print("loadAll: prepared \(list.count) satellites")
+
+            // Debug: Search for radios with missing orbital data
+            var untrackable = 0
+            for record in radios {
+                if !tles.contains { tle in tle.noradIndex == record.noradIndex } {
+                    untrackable += 1
+                }
+            }
+            
+            print("loadAll: unable to find \(untrackable) TLEs")
         }
     }
     
     /// Download and cache radio data
-    /// http://www.ne.jp/asahi/hamradio/je9pel/satslist.htm
-    /// http://www.dk3wn.info/p/?page_id=29535
-    static func loadRadioData() -> Promise<[ARS]> {
+    /// Source: http://www.ne.jp/asahi/hamradio/je9pel/satslist.htm
+    /// Other: http://www.dk3wn.info/p/?page_id=29535
+    static func loadRadioData() -> Promise<[JE3PEL]> {
         async {
             let url = URL(string: "https://www.ne.jp/asahi/hamradio/je9pel/satslist.csv")!
             let file = getDocumentsDirectory().appendingPathComponent("satslist.csv")
@@ -113,23 +132,24 @@ struct Cache {
             try? await(downloadIfStale(url: url, to: file, minutes: 1440))
             
             // Load data into cache from saved file
-            var active: [ARS] = []
-            var ignored = 0
             let stream = InputStream(url: file)!
             let csv = try CSVReader(stream: stream, delimiter: delimiter)
+            
+            var batch: [JE3PEL] = []
+            var ignored = 0
             while let row = csv.next() {
-                // Radio details from je9pel might have parse errors
-                if let ars = try? ARS(fromJE9PEL: row) {
-                    active.append(ars)
+                // Ignore JE3PEL records that parse wrong, aren't active, or don't have NORAD ids
+                if let ars = try? JE3PEL(fromCSV: row) {
+                    batch.append(ars)
                 } else {
                     ignored += 1
                 }
             }
             
-            print("loadRadioData: using \(active.count) sats")
-            print("loadRadioData: ignored \(ignored) sats")
+            print("loadRadioData: using \(batch.count) radio records")
+            print("loadRadioData: ignored \(ignored) radio records")
             
-            return active
+            return batch
         }
     }
     
@@ -137,7 +157,7 @@ struct Cache {
     /// NOTE: This source is missing 12 satellites denoted active on JE3PEL
     /// NOTE: I know that 2 are incorrectly marked as active, Space-Track has TLEs for 7 others, leaving 3 as "from caltech"???
     /// https://celestrak.com/NORAD/elements/
-    static func loadTLEs() -> Promise<[Int:TLE]> {
+    static func loadTLEs() -> Promise<[TLE]> {
         return async {
             let url = URL(string: "https://celestrak.com/NORAD/elements/active.txt")!
             let file = getDocumentsDirectory().appendingPathComponent("active.txt")
@@ -146,18 +166,19 @@ struct Cache {
             try? await(downloadIfStale(url: url, to: file, minutes: 1440))
             
             // Load data into cache from saved file
-            var batch: [Int:TLE] = [:]
             let text: String = try String(contentsOf: file, encoding: .utf8)
             let lines = text.components(separatedBy: .newlines).filter { (s: String) -> Bool in s.count > 0 }
+            
+            var batch: [TLE] = []
             for b in 0..<lines.count / 3 {
                 let i = b * 3
                 // TLEs from Celestrak will always parse
                 // Error is not handled here so it will bubble up if any fail to parse
-                let tle = try TLE(lines[i], lines[i+1], lines[i+2])
-                batch[tle.noradIndex] = tle
+                batch.append(try TLE(lines[i], lines[i+1], lines[i+2]))
             }
             
-            print("loadTLEs: loaded \(batch.count) tles")
+            print("loadTLEs: loaded \(batch.count) TLEs")
+            
             return batch
         }
     }

--- a/SatAR Lite/SatelliteListTableViewController.swift
+++ b/SatAR Lite/SatelliteListTableViewController.swift
@@ -5,18 +5,18 @@ class SatelliteListViewController: UITableViewController {
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         // List all satellites, even untracked ones
-        return Cache.sats.count
+        return Cache.list.count
     }
     
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = UITableViewCell(style: UITableViewCell.CellStyle.default, reuseIdentifier: "cell")
         
         // Populate the name and visibility checkmark
-        let sat = Cache.sats[indexPath.row]
+        let sat = Cache.list[indexPath.row]
         
-        cell.textLabel?.text = sat.commonName
+        cell.textLabel?.text = sat.tle.commonName
         
-        if tracking[sat.noradIndex] ?? false {
+        if sat.tracking {
             cell.accessoryType = UITableViewCell.AccessoryType.checkmark
         }
         
@@ -26,12 +26,11 @@ class SatelliteListViewController: UITableViewController {
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         // UITableViewCell.AccessoryType.<acc> may be useful
         
-        // Toggle checkmark and visibility
-        let sat = Cache.sats[indexPath.row]
+        // Toggle checkmark by mutating the struct in the list directly
+        let sat = Cache.list[indexPath.row]
+        sat.tracking = !sat.tracking
         
-        tracking[sat.noradIndex] = !(tracking[sat.noradIndex] ?? false)
-        
-        if (tracking[sat.noradIndex]!) {
+        if sat.tracking {
             tableView.cellForRow(at: indexPath)?.accessoryType = UITableViewCell.AccessoryType.checkmark
         } else {
             tableView.cellForRow(at: indexPath)?.accessoryType = UITableViewCell.AccessoryType.none

--- a/SatAR Lite/ViewController.swift
+++ b/SatAR Lite/ViewController.swift
@@ -9,7 +9,7 @@ class ViewController: UIViewController, ARSCNViewDelegate, CLLocationManagerDele
     var userLocation: CLLocation!
     
     var propagatorTimer: Timer!
-    var satelliteNodes: [Int:SCNNode] = [:]
+    var satelliteNodes: [AmateurRadioSatellite:SCNNode] = [:]
     
     @IBOutlet var sceneView: ARSCNView!
     
@@ -44,8 +44,8 @@ class ViewController: UIViewController, ARSCNViewDelegate, CLLocationManagerDele
         satelliteNodes.removeAll()
         
         // Create and attach nodes for tracked satellites
-        for (id, isTracking) in tracking {
-            if isTracking {
+        for ars in Cache.list {
+            if ars.tracking {
                 // SceneKit/AR coordinates are in meters
                 let plane = SCNPlane(width: 0.05, height: 0.05)
                 plane.firstMaterial!.diffuse.contents = "🛰".image()!
@@ -53,7 +53,7 @@ class ViewController: UIViewController, ARSCNViewDelegate, CLLocationManagerDele
                 node.constraints = [SCNBillboardConstraint()]
                 
                 // Save and attach node
-                satelliteNodes[id] = node
+                satelliteNodes[ars] = node
                 sceneView.scene.rootNode.addChildNode(node)
             }
         }
@@ -94,9 +94,9 @@ class ViewController: UIViewController, ARSCNViewDelegate, CLLocationManagerDele
         let lat = location.coordinate.latitude
         let lon = location.coordinate.longitude
         
-        for (id, node) in satelliteNodes {
+        for (ars, node) in satelliteNodes {
             // Calculate next topocentric coord (south, east, up)
-            let topo = Cache.getTopo(noradId: id, date: now, lat: lat, lon: lon)
+            let topo = ars.getTopo(date: now, lat: lat, lon: lon)
             let distance = topo.magnitude()
             
             // Place node in world (east, up, south)


### PR DESCRIPTION
Each satellite now has a TLE, a list of radios from JE3PEL, and a mutable tracking boolean. The list of radios is similar to how n2yo displays satellite radio data, even if it contains duplicate radios for the same TLE.

Related to #10, this new process now results in 152 satellites.